### PR TITLE
Add Bcast into aurora script

### DIFF
--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -9,3 +9,11 @@ export NEKRS_HOME=<your prefered location>/nekrs
 
 CC=mpicc CXX=mpic++ FC=mpif77 ./build.sh -DCMAKE_INSTALL_PREFIX=$NEKRS_HOME 
 ```
+
+
+## Update
+
+**2025-11-22**
+
+Add `NEKRS_CACHE_BCAST=1` to ease the filesystem pressure. When `flare` is busy,
+this seems to speed up the kernel load time.

--- a/Aurora/nrsqsub
+++ b/Aurora/nrsqsub
@@ -10,8 +10,8 @@ set -e
 : ${CPU_BIND_LIST:="1-8:9-16:17-24:25-32:33-40:41-48:53-60:61-68:69-76:77-84:85-92:93-100"}
 : ${OCCA_DPCPP_COMPILER_FLAGS:="-O3 -fsycl -fsycl-targets=intel_gpu_pvc -ftarget-register-alloc-mode=pvc:auto -fma"}
 : ${USE_ASCENT:=0}
-: ${NEKRS_CACHE_BCAST=1}
-: ${LOCAL_CACHE_HOME="/tmp/"}
+: ${NEKRS_CACHE_BCAST:=1}
+: ${LOCAL_CACHE_HOME:="/tmp/"}
 #--------------------------------------
 
 source $NEKRS_HOME/bin/nrsqsub_utils

--- a/Aurora/nrsqsub
+++ b/Aurora/nrsqsub
@@ -10,6 +10,8 @@ set -e
 : ${CPU_BIND_LIST:="1-8:9-16:17-24:25-32:33-40:41-48:53-60:61-68:69-76:77-84:85-92:93-100"}
 : ${OCCA_DPCPP_COMPILER_FLAGS:="-O3 -fsycl -fsycl-targets=intel_gpu_pvc -ftarget-register-alloc-mode=pvc:auto -fma"}
 : ${USE_ASCENT:=0}
+: ${NEKRS_CACHE_BCAST=1}
+: ${LOCAL_CACHE_HOME="/tmp/"}
 #--------------------------------------
 
 source $NEKRS_HOME/bin/nrsqsub_utils
@@ -58,6 +60,11 @@ fi
 echo "export NEKRS_HOME=$NEKRS_HOME" >>$SFILE
 echo "export NEKRS_GPU_MPI=$NEKRS_GPU_MPI" >>$SFILE
 echo "export MPICH_GPU_SUPPORT_ENABLED=$NEKRS_GPU_MPI" >> $SFILE
+
+echo "export NEKRS_CACHE_BCAST=$NEKRS_CACHE_BCAST" >>$SFILE
+echo "if [ \$NEKRS_CACHE_BCAST -eq 1 ]; then" >> $SFILE
+echo "  export NEKRS_LOCAL_TMP_DIR=$LOCAL_CACHE_HOME" >> $SFILE
+echo "fi" >> $SFILE
 
 echo "export OCCA_DPCPP_COMPILER_FLAGS=\"$OCCA_DPCPP_COMPILER_FLAGS\"" >> $SFILE
 


### PR DESCRIPTION
`NEKRS_CACHE_BCAST=1`, this seems to speed up the kernel loading time especially when flare is busy.