### PR TITLE
add NEKRS_JITC_NTHREADS

### DIFF
--- a/Aurora/nrsqsub
+++ b/Aurora/nrsqsub
@@ -113,7 +113,7 @@ if [ $RUN_ONLY -eq 0 ]; then
   add_build_CMD "$SFILE" "$CMD_build" "$TOTAL_RANKS"
 fi
 
-echo "unset NEKRS_JITC_NTHREADS" >> $CMD
+echo "unset NEKRS_JITC_NTHREADS" >> $SFILE
 
 if [ $BUILD_ONLY -eq 0 ]; then
   link_neknek_logfile "$SFILE"

--- a/Aurora/nrsqsub
+++ b/Aurora/nrsqsub
@@ -105,11 +105,15 @@ echo "export ZE_AFFINITY_MASK=\$gpu_id.\$tile_id" >> $CMD
 echo "\"\$@\"" >> $CMD
 chmod u+x $CMD
 
+echo "export NEKRS_JITC_NTHREADS=8" >> $SFILE
+
 if [ $RUN_ONLY -eq 0 ]; then
   echo -e "\n# precompilation" >>$SFILE
   CMD_build="mpiexec -n ${RANKS_FOR_BUILD} -ppn ${RANKS_FOR_BUILD} --cpu-bind=list:${CPU_BIND_LIST} -- ./${CMD} $bin --setup \${case_tmp} --backend ${NEKRS_BACKEND} --device-id 0 $extra_args --build-only \${ntasks_tmp}"
   add_build_CMD "$SFILE" "$CMD_build" "$TOTAL_RANKS"
 fi
+
+echo "unset NEKRS_JITC_NTHREADS" >> $CMD
 
 if [ $BUILD_ONLY -eq 0 ]; then
   link_neknek_logfile "$SFILE"

--- a/Aurora/nrsqsub
+++ b/Aurora/nrsqsub
@@ -10,6 +10,7 @@ set -e
 : ${CPU_BIND_LIST:="1-8:9-16:17-24:25-32:33-40:41-48:53-60:61-68:69-76:77-84:85-92:93-100"}
 : ${OCCA_DPCPP_COMPILER_FLAGS:="-O3 -fsycl -fsycl-targets=intel_gpu_pvc -ftarget-register-alloc-mode=pvc:auto -fma"}
 : ${USE_ASCENT:=0}
+: ${NEKRS_JITC_NTHREADS:=8}
 : ${NEKRS_CACHE_BCAST:=1}
 : ${LOCAL_CACHE_HOME:="/tmp/"}
 #--------------------------------------
@@ -105,15 +106,15 @@ echo "export ZE_AFFINITY_MASK=\$gpu_id.\$tile_id" >> $CMD
 echo "\"\$@\"" >> $CMD
 chmod u+x $CMD
 
-echo "export NEKRS_JITC_NTHREADS=8" >> $SFILE
-
 if [ $RUN_ONLY -eq 0 ]; then
   echo -e "\n# precompilation" >>$SFILE
+  if [ $USE_JITC_NTHREAD -gt 1 ]; then
+    echo "export NEKRS_JITC_NTHREADS=$NEKRS_JITC_NTHREADS" >> $SFILE
+  fi
   CMD_build="mpiexec -n ${RANKS_FOR_BUILD} -ppn ${RANKS_FOR_BUILD} --cpu-bind=list:${CPU_BIND_LIST} -- ./${CMD} $bin --setup \${case_tmp} --backend ${NEKRS_BACKEND} --device-id 0 $extra_args --build-only \${ntasks_tmp}"
   add_build_CMD "$SFILE" "$CMD_build" "$TOTAL_RANKS"
+  echo "unset NEKRS_JITC_NTHREADS" >> $SFILE
 fi
-
-echo "unset NEKRS_JITC_NTHREADS" >> $SFILE
 
 if [ $BUILD_ONLY -eq 0 ]; then
   link_neknek_logfile "$SFILE"

--- a/Frontier/nrsqsub
+++ b/Frontier/nrsqsub
@@ -158,12 +158,15 @@ if [ $NEKRS_CACHE_BCAST -eq 1 ]; then
 fi
 echo "ldd $bin" >> $SFILE
 
+echo "export NEKRS_JITC_NTHREADS=$cores_per_numa" >> $SFILE
+
 if [ $RUN_ONLY -eq 0 ]; then
   echo -e "\n# precompilation" >>$SFILE
   CMD_build="srun -N 1 -n $gpu_per_node $bin --backend $backend --device-id 0 $extra_args --setup \$case_tmp --build-only \$ntasks_tmp"
   add_build_CMD "$SFILE" "$CMD_build" "$ntasks"
 fi
 
+echo "unset NEKRS_JITC_NTHREADS" >> $SFILE
 
 if [ $BUILD_ONLY -eq 0 ]; then
   link_neknek_logfile "$SFILE"

--- a/Frontier/nrsqsub
+++ b/Frontier/nrsqsub
@@ -7,6 +7,7 @@ set -e
 : ${USE_COMPILER:="amd"} # amd or gnu (gcc13)
 : ${NEKRS_GPU_MPI:=0}
 : ${USE_ASCENT:=0}
+: ${NEKRS_JITC_NTHREADS:=7}
 
 NEKRS_CACHE_BCAST=1
 
@@ -158,15 +159,16 @@ if [ $NEKRS_CACHE_BCAST -eq 1 ]; then
 fi
 echo "ldd $bin" >> $SFILE
 
-echo "export NEKRS_JITC_NTHREADS=$cores_per_numa" >> $SFILE
-
 if [ $RUN_ONLY -eq 0 ]; then
   echo -e "\n# precompilation" >>$SFILE
+  if [ $USE_JITC_NTHREAD -gt 1 ]; then
+    echo "export NEKRS_JITC_NTHREADS=$NEKRS_JITC_NTHREADS" >> $SFILE
+  fi
   CMD_build="srun -N 1 -n $gpu_per_node $bin --backend $backend --device-id 0 $extra_args --setup \$case_tmp --build-only \$ntasks_tmp"
   add_build_CMD "$SFILE" "$CMD_build" "$ntasks"
+  echo "unset NEKRS_JITC_NTHREADS" >> $SFILE
 fi
 
-echo "unset NEKRS_JITC_NTHREADS" >> $SFILE
 
 if [ $BUILD_ONLY -eq 0 ]; then
   link_neknek_logfile "$SFILE"

--- a/Juwles-booster/nrsqsub
+++ b/Juwles-booster/nrsqsub
@@ -2,6 +2,7 @@
 set -e
 
 : ${QUEUE:="gpu"}
+: ${NEKRS_JITC_NTHREADS:=12}
 
 source $NEKRS_HOME/bin/nrsqsub_utils
 setup $# 1
@@ -72,8 +73,12 @@ echo "export OMP_NUM_THREADS=\${SLURM_CPUS_PER_TASK}" >>$SFILE
 
 if [ $RUN_ONLY -eq 0 ]; then
   echo -e "\n# precompilation" >>$SFILE
+  if [ $USE_JITC_NTHREAD -gt 1 ]; then
+    echo "export NEKRS_JITC_NTHREADS=$NEKRS_JITC_NTHREADS" >> $SFILE
+  fi
   CMD_build="srun --cpus-per-task=\${SLURM_CPUS_PER_TASK} --cpu-bind=cores $bin --backend $backend --device-id 0 --setup \$case_tmp $extra_args --build-only \$ntasks_tmp"
   add_build_CMD "$SFILE" "$CMD_build" "$ntasks"
+  echo "unset NEKRS_JITC_NTHREADS" >> $SFILE
 fi
 
 if [ $BUILD_ONLY -eq 0 ]; then

--- a/Perlmutter/nrsqsub
+++ b/Perlmutter/nrsqsub
@@ -2,6 +2,7 @@
 set -e
 
 : ${QUEUE:="regular"} # https://docs.nersc.gov/jobs/policy/#perlmutter-gpu
+: ${NEKRS_JITC_NTHREADS:=8}
 
 source $NEKRS_HOME/bin/nrsqsub_utils
 setup $# 1
@@ -71,8 +72,12 @@ echo "fi" >> $SFILE
 
 if [ $RUN_ONLY -eq 0 ]; then
   echo -e "\n# precompilation" >>$SFILE
+  if [ $USE_JITC_NTHREAD -gt 1 ]; then
+    echo "export NEKRS_JITC_NTHREADS=$NEKRS_JITC_NTHREADS" >> $SFILE
+  fi
   CMD_build="srun -N 1 $bin --backend $backend --device-id 0 --setup \$case_tmp $extra_args --build-only \$ntasks_tmp"
   add_build_CMD "$SFILE" "$CMD_build" "$ntasks"
+  echo "unset NEKRS_JITC_NTHREADS" >> $SFILE
 fi
 
 if [ $BUILD_ONLY -eq 0 ]; then

--- a/Polaris/nrsqsub
+++ b/Polaris/nrsqsub
@@ -94,11 +94,15 @@ echo "export CUDA_VISIBLE_DEVICES=\$gpu_id" >>$CMD
 echo "\$*" >>$CMD
 chmod 755 $CMD
 
+echo "export NEKRS_JITC_NTHREADS=8" >> $SFILE
+
 if [ $RUN_ONLY -eq 0 ]; then
   echo -e "\n# precompilation" >>$SFILE
   CMD_build="mpiexec -n $gpu_per_node -ppn $gpu_per_node -d $cores_per_numa --cpu-bind depth ./$CMD $bin --setup \${case_tmp} --backend ${backend} --device-id 0 $extra_args --build-only \$ntasks_tmp"
   add_build_CMD "$SFILE" "$CMD_build" "$ntasks"
 fi
+
+echo "unset NEKRS_JITC_NTHREADS" >> $SFILE
 
 if [ $BUILD_ONLY -eq 0 ]; then
   link_neknek_logfile "$SFILE"

--- a/Polaris/nrsqsub
+++ b/Polaris/nrsqsub
@@ -3,6 +3,7 @@ set -e
 
 : ${QUEUE:="prod"} # debug, debug-scaling, prod https://docs.alcf.anl.gov/running-jobs/job-and-queue-scheduling/
 : ${USE_ASCENT:=0}
+: ${NEKRS_JITC_NTHREADS:=7}
 
 source $NEKRS_HOME/bin/nrsqsub_utils
 setup $# 1
@@ -94,15 +95,15 @@ echo "export CUDA_VISIBLE_DEVICES=\$gpu_id" >>$CMD
 echo "\$*" >>$CMD
 chmod 755 $CMD
 
-echo "export NEKRS_JITC_NTHREADS=8" >> $SFILE
-
 if [ $RUN_ONLY -eq 0 ]; then
   echo -e "\n# precompilation" >>$SFILE
+  if [ $USE_JITC_NTHREAD -gt 1 ]; then
+    echo "export NEKRS_JITC_NTHREADS=$NEKRS_JITC_NTHREADS" >> $SFILE
+  fi
   CMD_build="mpiexec -n $gpu_per_node -ppn $gpu_per_node -d $cores_per_numa --cpu-bind depth ./$CMD $bin --setup \${case_tmp} --backend ${backend} --device-id 0 $extra_args --build-only \$ntasks_tmp"
   add_build_CMD "$SFILE" "$CMD_build" "$ntasks"
+  echo "unset NEKRS_JITC_NTHREADS" >> $SFILE
 fi
-
-echo "unset NEKRS_JITC_NTHREADS" >> $SFILE
 
 if [ $BUILD_ONLY -eq 0 ]; then
   link_neknek_logfile "$SFILE"


### PR DESCRIPTION
This seems to massively improve the precompilation time.

Need to figure out whether the threads are spawn randomly for the whole node or it's within the resource set exclusively.

@aparikusu

Comparison (`--build-only`)
- Aurora

- Frontier
  ```
  nek (85.2028s) -> (85.564s)
  udf (42.3389s) -> (42.9456s)
  knl (301.416s) -> (62.8944s)
  ```
- Polaris
  ```
  nek (18.1142s) -> (18.0377s)
  udf (9.70951s) -> (9.6604s)
  knl (158.506s) -> (23.0728s)
  ```