### PR TITLE
Ascent Aurora: use newer module, tested on Aurora

### DIFF
--- a/Aurora/nrsqsub
+++ b/Aurora/nrsqsub
@@ -48,12 +48,12 @@ echo "echo Running on nodes \`cat \$PBS_NODEFILE\`" >>$SFILE
 echo "module load cmake" >> $SFILE
 if [ $USE_ASCENT -eq 1 ]; then
   echo "module use /soft/modulefiles/" >> $SFILE
-  echo "module load ascent/develop/2025-03-19-c1f63e7-openmp" >> $SFILE
+  echo "module load ascent/release/v0.9.5" >> $SFILE
 fi
 echo "module list" >> $SFILE
 
 if [ $USE_ASCENT -eq 1 ]; then
-  echo "export NEKRS_ASCENT_INSTALL_DIR=\"/soft/visualization/ascent/develop/2025-03-19-c1f63e7-openmp/ascent-checkout/\"" >>$SFILE
+  echo "export NEKRS_ASCENT_INSTALL_DIR=\"/soft/visualization/ascent/release/v0.9.5/ascent-checkout/\"" >>$SFILE
   echo "export NEKRS_MPI_THREAD_MULTIPLE=1" >>$SFILE # ascent async mode
 fi
 


### PR DESCRIPTION
`ascent/develop/2025-03-19-c1f63e7-*` depends on `/opt/aurora/24.180.3/`, which is no longer available on Aurora
`ascent/develop/2025-06-06-test-openmp` depends on `/opt/aurora/24.347.0/`, which is no longer available on Aurora
The only module that is working is `ascent/release/v0.9.5`, which depends on `/opt/aurora/26.26.0/`